### PR TITLE
Process when client side data load errors

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/aggregate/processing/AggregateProcessingLambdaRunner.scala
+++ b/src/main/scala/uk/gov/nationalarchives/aggregate/processing/AggregateProcessingLambdaRunner.scala
@@ -4,7 +4,7 @@ import cats.effect.unsafe.implicits.global
 import uk.gov.nationalarchives.aggregate.processing.AggregateProcessingLambda.AggregateEvent
 
 object AggregateProcessingLambdaRunner extends App {
-  val event = AggregateEvent("placeholder", "placeholder")
+  val event = AggregateEvent("placeholder", "placeholder", dataLoadErrors = false)
 
   new AggregateProcessingLambda().processEvent(event).unsafeRunSync()
 }

--- a/src/main/scala/uk/gov/nationalarchives/aggregate/processing/modules/Common.scala
+++ b/src/main/scala/uk/gov/nationalarchives/aggregate/processing/modules/Common.scala
@@ -24,7 +24,7 @@ object Common {
 
   object ProcessErrorType extends Enumeration {
     type ProcessErrorType = Value
-    val ClientSideMetadataError: Value = Value("CLIENT_SIDE_METADATA")
+    val ClientDataLoadError: Value = Value("CLIENT_DATA_LOAD")
     val EncodingError: Value = Value("ENCODING")
     val EventError: Value = Value("EVENT")
     val JsonError: Value = Value("JSON")
@@ -34,6 +34,7 @@ object Common {
 
   object ProcessErrorValue extends Enumeration {
     type ProcessErrorValue = Value
+    val Failure: Value = Value("FAILURE")
     val Invalid: Value = Value("INVALID")
     val ReadError: Value = Value("READ_ERROR")
   }

--- a/src/test/scala/uk/gov/nationalarchives/aggregate/processing/AggregateProcessingLambdaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/aggregate/processing/AggregateProcessingLambdaSpec.scala
@@ -21,7 +21,8 @@ class AggregateProcessingLambdaSpec extends ExternalServiceSpec {
     s"""
     {
       "metadataSourceBucket": "source-bucket",
-      "metadataSourceObjectPrefix": "$userId/$source/$consignmentId/$category"
+      "metadataSourceObjectPrefix": "$userId/$source/$consignmentId/$category",
+      "dataLoadErrors": false
     }
     """.stripMargin
 
@@ -63,6 +64,57 @@ class AggregateProcessingLambdaSpec extends ExternalServiceSpec {
 
     wiremockGraphqlServer.verify(
       exactly(4),
+      postRequestedFor(anyUrl())
+        .withUrl("/graphql")
+    )
+  }
+
+  "handleRequest" should "process request correctly where client side data load errors are present" in {
+    authOkJson()
+    mockS3GetObjectStream(userId, consignmentId.toString, matchId)
+    mockS3ListBucketResponse(userId, consignmentId, List(matchId))
+    mockSfnResponseOk()
+    mockGraphQlAddFilesAndMetadataResponse
+    mockGraphQlUpdateConsignmentStatusResponse
+    val mockContext = mock[Context]
+
+    val dataLoadErrorsMessageBody: String =
+      s"""
+    {
+      "metadataSourceBucket": "source-bucket",
+      "metadataSourceObjectPrefix": "$userId/$source/$consignmentId/$category",
+      "dataLoadErrors": true
+    }
+    """.stripMargin
+
+    val message = new SQSMessage()
+    message.setBody(dataLoadErrorsMessageBody)
+
+    val messages: java.util.List[SQSMessage] = List(message).asJava
+    val sqsEvent = new SQSEvent()
+    sqsEvent.setRecords(messages)
+    new AggregateProcessingLambda().handleRequest(sqsEvent, mockContext)
+
+    wiremockS3.verify(
+      exactly(1),
+      getRequestedFor(anyUrl())
+        .withUrl(s"/?list-type=2&max-keys=1000&prefix=$userId%2F$source%2F$consignmentId%2F$category")
+    )
+
+    wiremockS3.verify(
+      exactly(0),
+      getRequestedFor(anyUrl())
+        .withUrl(s"/$userId/$source/$consignmentId/$category/$matchId.metadata")
+    )
+
+    wiremockSfnServer.verify(
+      exactly(0),
+      postRequestedFor(anyUrl())
+        .withRequestBody(containing(s"transfer_service_$consignmentId"))
+    )
+
+    wiremockGraphqlServer.verify(
+      exactly(1),
       postRequestedFor(anyUrl())
         .withUrl("/graphql")
     )

--- a/src/test/scala/uk/gov/nationalarchives/aggregate/processing/modules/CommonSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/aggregate/processing/modules/CommonSpec.scala
@@ -24,7 +24,7 @@ class CommonSpec extends AnyFlatSpec {
 
   "ProcessErrorType" should "contain the correct enums" in {
     val processErrorType = Common.ProcessErrorType
-    val expectedValues = List("CLIENT_SIDE_METADATA", "ENCODING", "EVENT", "JSON", "OBJECT_KEY", "S3")
+    val expectedValues = List("CLIENT_DATA_LOAD", "ENCODING", "EVENT", "JSON", "OBJECT_KEY", "S3")
 
     processErrorType.values.size shouldBe 6
     processErrorType.values.map(_.toString).toList shouldEqual expectedValues
@@ -32,9 +32,9 @@ class CommonSpec extends AnyFlatSpec {
 
   "ProcessErrorValue" should "contain the correct enums" in {
     val processErrorValue = Common.ProcessErrorValue
-    val expectedValues = List("INVALID", "READ_ERROR")
+    val expectedValues = List("FAILURE", "INVALID", "READ_ERROR")
 
-    processErrorValue.values.size shouldBe 2
+    processErrorValue.values.size shouldBe 3
     processErrorValue.values.map(_.toString).toList shouldEqual expectedValues
   }
 


### PR DESCRIPTION
Handle where there have been errors on the client side

The triggering service for the lambda will pass in parmater on the event to indicate

Where client side data load errors do not process the assets