### PR TITLE
Double the metadata object key count

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/aggregate/processing/AggregateProcessingLambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/aggregate/processing/AggregateProcessingLambda.scala
@@ -72,28 +72,30 @@ class AggregateProcessingLambda extends RequestHandler[SQSEvent, Unit] {
     val assetSource = objectContext.assetSource.get
     val dryRun = objectsPrefix.contains(DryRunMetadata.id)
     val ignoreSiteName = event.ignoreSiteName
-    val objectsExpectedCount = event.loadedNumberOfFiles
+    val allObjectsExpectedCount = event.loadedNumberOfFiles
     logger.info(s"Starting processing consignment: $consignmentId")
     for {
       details <- persistenceApi.getConsignmentDetails(consignmentId)
       incorrectState = !stateCorrect(details.get.consignmentStatuses)
-      s3Objects <- IO(s3Utils.listAllObjectsWithPrefix(sourceBucket, objectsPrefix))
-      objectKeys = s3Objects.map(_.key())
-      objectKeysCount = objectKeys.size
+      s3MetadataObjects <- IO(s3Utils.listAllObjectsWithPrefix(sourceBucket, objectsPrefix))
+      metadataObjectKeys = s3MetadataObjects.map(_.key())
+      metadataObjectKeysCount = metadataObjectKeys.size
       assetProcessingResult <- dataLoadErrors match {
         case _ if incorrectState =>
           errorHandling.handleError(incorrectStateError(consignmentId), logger)
           IO(errorProcessingResult)
-        case _ if objectKeysCount != objectsExpectedCount =>
-          errorHandling.handleError(objectCountMismatch(consignmentId, objectsExpectedCount, objectKeysCount), logger)
+        // Each metadata object has a digital object associated with it
+        // Double the metadata object count to get the correct number of objects
+        case _ if metadataObjectKeysCount * 2 != allObjectsExpectedCount =>
+          errorHandling.handleError(objectCountMismatch(consignmentId, allObjectsExpectedCount, metadataObjectKeysCount), logger)
           IO(errorProcessingResult)
         case _ if dataLoadErrors =>
           errorHandling.handleError(dataLoadError(consignmentId), logger)
           IO(errorProcessingResult)
-        case _ if objectKeys.isEmpty =>
+        case _ if metadataObjectKeys.isEmpty =>
           errorHandling.handleError(noObjectsError(consignmentId, objectContext.category.get), logger)
           IO(errorProcessingResult)
-        case _ => processAssets(userId, consignmentId, sourceBucket, objectKeys, dryRun, ignoreSiteName)
+        case _ => processAssets(userId, consignmentId, sourceBucket, metadataObjectKeys, dryRun, ignoreSiteName)
       }
       orchestrationEvent = AggregateProcessingEvent(
         assetSource,

--- a/src/test/scala/uk/gov/nationalarchives/aggregate/processing/AggregateProcessingLambdaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/aggregate/processing/AggregateProcessingLambdaSpec.scala
@@ -26,7 +26,7 @@ class AggregateProcessingLambdaSpec extends ExternalServiceSpec with TableDriven
       "metadataSourceObjectPrefix": "$userId/$assetSource/$consignmentId/$category",
       "dataLoadErrors": false,
       "ignoreSiteName": false,
-      "loadedNumberOfFiles": 1
+      "loadedNumberOfFiles": 2
     }
     """.stripMargin
 
@@ -180,7 +180,7 @@ class AggregateProcessingLambdaSpec extends ExternalServiceSpec with TableDriven
             "metadataSourceObjectPrefix": "$userId/$assetSource/$consignmentId/$category",
             "dataLoadErrors": true,
             "ignoreSiteName": false,
-            "loadedNumberOfFiles": 1
+            "loadedNumberOfFiles": 2
           }
           """.stripMargin
 
@@ -242,7 +242,7 @@ class AggregateProcessingLambdaSpec extends ExternalServiceSpec with TableDriven
             "metadataSourceObjectPrefix": "$userId/$assetSource/$consignmentId/$category",
             "dataLoadErrors": true,
             "ignoreSiteName": false,
-            "loadedNumberOfFiles": 2
+            "loadedNumberOfFiles": 3
           }
           """.stripMargin
 
@@ -450,7 +450,7 @@ class AggregateProcessingLambdaSpec extends ExternalServiceSpec with TableDriven
               "metadataSourceObjectPrefix": "$userId/$assetSource/$consignmentId/$category",
               "dataLoadErrors": false,
               "ignoreSiteName": false,
-              "loadedNumberOfFiles": 1
+              "loadedNumberOfFiles": 2
             }
             """.stripMargin
 
@@ -524,7 +524,7 @@ class AggregateProcessingLambdaSpec extends ExternalServiceSpec with TableDriven
               "metadataSourceObjectPrefix": "$userId/$assetSource/$consignmentId/$category",
               "dataLoadErrors": false,
               "ignoreSiteName": false,
-              "loadedNumberOfFiles": 1
+              "loadedNumberOfFiles": 2
             }
             """.stripMargin
 


### PR DESCRIPTION
Event number of files loaded includes the metadata object and the digital object, therefore the correct count should be double the number of metadata object keys

This will work while there is always a digital object associated with the metadata object.

Will need to re-visit if start handling retained records